### PR TITLE
chore: remove version definition in composer.json

### DIFF
--- a/.github/workflows/tests_build.yaml
+++ b/.github/workflows/tests_build.yaml
@@ -23,6 +23,8 @@ jobs:
           coverage: xdebug
       - name: Checkout
         uses: actions/checkout@v2
+      - name: "Validate composer.json"
+        run: "composer validate"
       - name: "Install dependencies"
         run: "composer install"
       - name: "CS Check"

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,6 @@
 {
     "name": "yllumi/ci4-pages",
     "description": "Page based router for CodeIgniter 4",
-    "version": "1.0.2",
     "type": "library",
     "require": {
         "php": "^8.1",


### PR DESCRIPTION
version in composer.json is not recommended by `composer validate` command

```
➜  ci4-pages git:(main) composer validate
./composer.json is valid, but with a few warnings
See https://getcomposer.org/doc/04-schema.md for details on the schema
# General warnings
- The version field is present, it is recommended to leave it out if the package is published on Packagist.
```

Also add gitHub actions step to validate it.

as `composer.lock` is not committed, on local, `composer.lock` can be regenerated:

```
composer update
```