### PR TITLE
Fix non string value default page on PageRouter::pageBasedRoute()

### DIFF
--- a/src/PageRouter.php
+++ b/src/PageRouter.php
@@ -18,6 +18,7 @@ use CodeIgniter\Exceptions\PageNotFoundException;
 use CodeIgniter\HTTP\Exceptions\BadRequestException;
 use CodeIgniter\HTTP\ResponseInterface;
 use CodeIgniter\Router\Router;
+use RuntimeException;
 
 /**
  * Page based router.
@@ -70,6 +71,10 @@ class PageRouter extends Router
         // Set default page for root uri
         if ($uri === '' || $uri === '0') {
             $uri = config('App')->defaultPage ?? 'home';
+
+            if (! is_string($uri)) {
+                throw new RuntimeException('App Config defaultPage must be a string.');
+            }
         }
 
         // Set default variables

--- a/src/PageRouter.php
+++ b/src/PageRouter.php
@@ -69,7 +69,7 @@ class PageRouter extends Router
         $uri       = trim($uri, '/');
 
         // Set default page for root uri
-        if ($uri === '' || $uri === '0') {
+        if ($uri === '') {
             $uri = config('App')->defaultPage ?? 'home';
 
             if (! is_string($uri)) {


### PR DESCRIPTION
Latest build on main branch show diff:

```diff
-        $uriSegments = explode('/', $uri);
+        $uriSegments = explode('/', (string) $uri);
```

which seems because of latest PHPStan that rector rely on.

https://github.com/yllumi/ci4-pages/actions/runs/12922169683/job/36037423639#step:7:29

This patch ensure verify non-string `config('App')->defaultPage` early so cast string is not needed.